### PR TITLE
New condition for hasNullRelease

### DIFF
--- a/package-aggregator/main.go
+++ b/package-aggregator/main.go
@@ -57,14 +57,18 @@ func main() {
 	}
 }
 
-// hasNullRelease returns whether there is a release with the tag "null". This indicates that
+// hasNullRelease returns whether the latest release has the tag "null". This indicates that
 // the build state of this repository is currently not of interest for the Gardenlinux team
 // A simple boolean as a return value is not really sufficient as a return value, there is no way
 // to communicate if an API call has failed etc, but I consider this "good enough" for this use-case.
 // The successful retrieval of a null-release returns a true, everything else a false.
 func hasNullRelease(repoName string, client *github.Client, ctx context.Context) bool {
-	repoRelease, _, _ := client.Repositories.GetReleaseByTag(ctx, orga, repoName, "null")
-	return repoRelease != nil
+	repoRelease, _, err := client.Repositories.GetLatestRelease(ctx, orga, repoName)
+	if err != nil {
+		slog.Warn("failed getting latest release, returning hasNullRelease as false", "err", err.Error())
+		return false
+	}
+	return *repoRelease.TagName == "null"
 }
 
 func getPackageStateByRepoName(repoName string, client *github.Client, ctx context.Context) packageState {

--- a/package-aggregator/main.go
+++ b/package-aggregator/main.go
@@ -23,7 +23,7 @@ type packageState struct {
 	// or it can be workFlowNotFound (in case no workflow is defined in build.yml)
 	// or it can be noRunFound (in case a workflow file in build.yml exists, but no run has been executed yet)
 	// or it can be brokenTimestamp (in case the GitHub API returns an invalid timestamp for the run)
-	// or it can be hasNullRelease in case there is a release that has the tag "null"
+	// or it can be hasNullRelease in case there is a release that is marked as latest and has the tag "null"
 	Status string `json:"Status"`
 	// Time is the Time at which this tool tried to grab data from GitHub
 	// in case there is a workflow run that contains more precise data (UpdatedAt), that timestamp is used


### PR DESCRIPTION
After this commit a repository has to have a release marked as latest
and with its tag named "null" to be reported with the state
"hasNullRelease". Before this commit it has been sufficient if a release
with the tagname "null" exists at all. The difference can be seen in the
package-openssl repository. Before this commit the repository is
reported with state "hasNullRelease". After this commit it is reported
as "failure".

Signed-off-by: Malte Münch <muench@b1-systems.de>
