### PR TITLE
Fix 'go: download go1.22 for darwin/arm64: toolchain not available' error

### DIFF
--- a/package-aggregator/go.mod
+++ b/package-aggregator/go.mod
@@ -7,4 +7,4 @@ require (
 
 require github.com/google/go-querystring v1.1.0 // indirect
 
-go 1.22
+go 1.22.0

--- a/package-aggregator/main.go
+++ b/package-aggregator/main.go
@@ -160,7 +160,7 @@ func getPackageRepoNames(client *github.Client, ctx context.Context) []string {
 	}
 
 	// collect the remaining into slice
-	for repo, _ := range prefixRepos {
+	for repo := range prefixRepos {
 		packageRepos = append(packageRepos, repo)
 	}
 
@@ -185,7 +185,7 @@ func config() {
 	flag.StringVar(&orga, "orga", "gardenlinux", "The GitHub organization name to scrape")
 	flag.StringVar(&prefix, "prefix", "package-", "filter the organizations repos by this prefix")
 	flag.StringVar(&workflowfile, "workflowfile", "build.yml", "scrape workflow runs of this file")
-	flag.StringVar(&exclude, "exclude", "", "a comma seperated list of repositories to exclude from scraping")
+	flag.StringVar(&exclude, "exclude", "", "a comma separated list of repositories to exclude from scraping")
 	flag.Float64Var(&stale, "stale", 24, "time after which a package should be considered stale (even if the run was successful)")
 
 	flag.Parse()


### PR DESCRIPTION
**What this PR does / why we need it**:

According to https://stackoverflow.com/a/78643571, the .0 is required for go toolchain. Should not make a difference in github actions, but did on my mac. I did not look into this go toolchain thing in detail.
