### PR TITLE
update warning color variables for improved visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,9 +30,9 @@
     --color-progress-light: #ebf8ff; /* SAP Blue/1 */
     --color-progress-dark: #0040b0; /* SAP Blue/9 */
 
-    --color-warning: #e76500; /* SAP Mango/6 */
-    --color-warning-light: #fff8d6; /* SAP Mango/1 */
-    --color-warning-dark: #8d2a00; /* SAP Mango/9 */
+    --color-warning: #ffe066; /* Soft yellow with a hint of lime */
+    --color-warning-light: #fffbe0; /* Very light yellow */
+    --color-warning-dark: #bfa600; /* Muted golden yellow */
 
     --color-info: #470ced; /* SAP Indigo/8 */
     --color-info-light: #f1ecff; /* SAP Indigo/1 */


### PR DESCRIPTION
**What this PR does / why we need it**:

Make the 'failure' and the 'warning' state easier to distinguish visually
<img width="1508" height="821" alt="Screenshot 2025-07-31 at 11 17 47" src="https://github.com/user-attachments/assets/5273c888-cda1-4ebd-a415-04c5af09514c" />
<img width="1363" height="886" alt="Screenshot 2025-07-31 at 11 18 45" src="https://github.com/user-attachments/assets/73cd0ebb-3da5-4ad1-8258-7a268731e1cf" />



**Which issue(s) this PR fixes**:
Fixes #11
