### PR TITLE
feat: in overview section add stacked dots for stages 2, 3, and 4

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,26 +163,64 @@
                                 class="current-stages"
                                 title="Stages: Package | Repo | Build | Publish"
                             >
-                                <span
-                                    class="current-stage-dot unknown"
-                                    id="current-stage-1"
+                                <div
+                                    class="current-stage-dot-container"
                                     title="Package Builds"
-                                ></span>
-                                <span
-                                    class="current-stage-dot unknown"
-                                    id="current-stage-2"
+                                >
+                                    <span
+                                        class="current-stage-dot unknown"
+                                        id="current-stage-1"
+                                        title="Package Builds"
+                                    ></span>
+                                </div>
+                                <div
+                                    class="current-stage-dots-stacked"
+                                    id="current-stage-2-container"
                                     title="Repository"
-                                ></span>
-                                <span
-                                    class="current-stage-dot unknown"
-                                    id="current-stage-3"
+                                >
+                                    <span
+                                        class="current-stage-dot unknown"
+                                        id="current-stage-2-top"
+                                        title="Repo Update"
+                                    ></span>
+                                    <span
+                                        class="current-stage-dot unknown"
+                                        id="current-stage-2-bottom"
+                                        title="Repo Build"
+                                    ></span>
+                                </div>
+                                <div
+                                    class="current-stage-dots-stacked"
+                                    id="current-stage-3-container"
                                     title="Build & Release"
-                                ></span>
-                                <span
-                                    class="current-stage-dot unknown"
-                                    id="current-stage-4"
+                                >
+                                    <span
+                                        class="current-stage-dot unknown"
+                                        id="current-stage-3-top"
+                                        title="Garden Linux Nightly - Schedule"
+                                    ></span>
+                                    <span
+                                        class="current-stage-dot unknown"
+                                        id="current-stage-3-bottom"
+                                        title="Build and publish a release - Manual"
+                                    ></span>
+                                </div>
+                                <div
+                                    class="current-stage-dots-stacked"
+                                    id="current-stage-4-container"
                                     title="Publish"
-                                ></span>
+                                >
+                                    <span
+                                        class="current-stage-dot unknown"
+                                        id="current-stage-4-top"
+                                        title="Publish to ghcr.io"
+                                    ></span>
+                                    <span
+                                        class="current-stage-dot unknown"
+                                        id="current-stage-4-bottom"
+                                        title="Publish to S3"
+                                    ></span>
+                                </div>
                             </div>
 
                             <div

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -1143,7 +1143,8 @@ export function updatePipelineHierarchy() {
         packageStatus,
         workflowRunData,
         WORKFLOW_IDS,
-        getGlDays
+        getGlDays,
+        workflowStatuses
     );
 
     console.log("Stage statuses:", stageStatuses);
@@ -1261,7 +1262,8 @@ async function loadHistoricDay(glDays) {
             glDays,
             date: glDate,
             packageStatus,
-            workflowStatus: stageStatuses, // for small dots
+            workflowStatus: stageStatuses, // for small dots (aggregated stage statuses)
+            workflowStatuses, // individual workflow statuses for stacked dots
             duration,
             pipelineStatus, // for main dot and row coloring
         };

--- a/src/ui.js
+++ b/src/ui.js
@@ -52,8 +52,40 @@ export function renderHistoricReleases(historicData) {
     }));
 
     historicList.innerHTML = safeHistoricData
-        .map(
-            (day) => `
+        .map((day) => {
+            // Get individual workflow statuses for stages 2, 3, and 4
+            const repoUpdateStatus =
+                day.workflowStatuses &&
+                day.workflowStatuses[WORKFLOW_IDS.REPO_UPDATE]
+                    ? day.workflowStatuses[WORKFLOW_IDS.REPO_UPDATE]
+                    : "unknown";
+            const repoBuildStatus =
+                day.workflowStatuses &&
+                day.workflowStatuses[WORKFLOW_IDS.REPO_BUILD]
+                    ? day.workflowStatuses[WORKFLOW_IDS.REPO_BUILD]
+                    : "unknown";
+            const nightlyStatus =
+                day.workflowStatuses &&
+                day.workflowStatuses[WORKFLOW_IDS.NIGHTLY]
+                    ? day.workflowStatuses[WORKFLOW_IDS.NIGHTLY]
+                    : "unknown";
+            const manualReleaseStatus =
+                day.workflowStatuses &&
+                day.workflowStatuses[WORKFLOW_IDS.MANUAL_RELEASE]
+                    ? day.workflowStatuses[WORKFLOW_IDS.MANUAL_RELEASE]
+                    : "unknown";
+            const publishGhcrStatus =
+                day.workflowStatuses &&
+                day.workflowStatuses[WORKFLOW_IDS.PUBLISH_GHCR]
+                    ? day.workflowStatuses[WORKFLOW_IDS.PUBLISH_GHCR]
+                    : "unknown";
+            const publishS3Status =
+                day.workflowStatuses &&
+                day.workflowStatuses[WORKFLOW_IDS.PUBLISH_S3]
+                    ? day.workflowStatuses[WORKFLOW_IDS.PUBLISH_S3]
+                    : "unknown";
+
+            return `
         <a href="?gl=${day.glDays}&no_historic_releases=true" target="_blank" class="historic-release-row ${day.pipelineStatus}" title="View detailed dashboard for GL ${day.glDays}">
             <div class="historic-gl-version ${day.pipelineStatus}">GL ${day.glDays}</div>
             <div class="historic-date">${day.date}</div>
@@ -64,10 +96,21 @@ export function renderHistoricReleases(historicData) {
             </div>
 
             <div class="historic-stages" title="Stages: Package | Repo | Build | Publish">
-                <span class="historic-stage-dot ${day.workflowStatus && day.workflowStatus["stage-1"] ? day.workflowStatus["stage-1"] : "unknown"}" title="Package Builds"></span>
-                <span class="historic-stage-dot ${day.workflowStatus && day.workflowStatus["stage-2"] ? day.workflowStatus["stage-2"] : "unknown"}" title="Repository"></span>
-                <span class="historic-stage-dot ${day.workflowStatus && day.workflowStatus["stage-3"] ? day.workflowStatus["stage-3"] : "unknown"}" title="Build & Release"></span>
-                <span class="historic-stage-dot ${day.workflowStatus && day.workflowStatus["stage-4"] ? day.workflowStatus["stage-4"] : "unknown"}" title="Publish"></span>
+                <div class="historic-stage-dot-container" title="Package Builds">
+                    <span class="historic-stage-dot ${day.workflowStatus && day.workflowStatus["stage-1"] ? day.workflowStatus["stage-1"] : "unknown"}" title="Package Builds"></span>
+                </div>
+                <div class="historic-stage-dots-stacked" title="Repository">
+                    <span class="historic-stage-dot ${repoUpdateStatus}" title="Repo Update"></span>
+                    <span class="historic-stage-dot ${repoBuildStatus}" title="Repo Build"></span>
+                </div>
+                <div class="historic-stage-dots-stacked" title="Build & Release">
+                    <span class="historic-stage-dot ${nightlyStatus}" title="Garden Linux Nightly - Schedule"></span>
+                    <span class="historic-stage-dot ${manualReleaseStatus}" title="Build and publish a release - Manual"></span>
+                </div>
+                <div class="historic-stage-dots-stacked" title="Publish">
+                    <span class="historic-stage-dot ${publishGhcrStatus}" title="Publish to ghcr.io"></span>
+                    <span class="historic-stage-dot ${publishS3Status}" title="Publish to S3"></span>
+                </div>
             </div>
 
             <div class="historic-package-status">
@@ -105,8 +148,8 @@ export function renderHistoricReleases(historicData) {
                 }
             </div>
         </a>
-    `
-        )
+    `;
+        })
         .join("");
 }
 
@@ -136,7 +179,8 @@ export function updateCurrentReleaseSummary(
     packageStatus,
     workflowRunData,
     WORKFLOW_IDS,
-    getGlDays
+    getGlDays,
+    workflowStatuses = {}
 ) {
     const glDays = getGlDays();
     const formattedDate = formatDetailedDate(glDays);
@@ -164,12 +208,53 @@ export function updateCurrentReleaseSummary(
     }
 
     // Update stage dots
-    for (let i = 1; i <= 4; i++) {
-        const stageDot = document.getElementById(`current-stage-${i}`);
-        if (stageDot) {
-            const stageStatus = stageStatuses[`stage-${i}`] || "unknown";
-            setElementStatus(stageDot, stageStatus);
-        }
+    // Stage 1: single dot
+    const stage1Dot = document.getElementById("current-stage-1");
+    if (stage1Dot) {
+        const stageStatus = stageStatuses["stage-1"] || "unknown";
+        setElementStatus(stage1Dot, stageStatus);
+    }
+
+    // Stage 2: stacked dots for individual workflows
+    const stage2TopDot = document.getElementById("current-stage-2-top");
+    const stage2BottomDot = document.getElementById("current-stage-2-bottom");
+    if (stage2TopDot) {
+        const repoUpdateStatus =
+            workflowStatuses[WORKFLOW_IDS.REPO_UPDATE] || "unknown";
+        setElementStatus(stage2TopDot, repoUpdateStatus);
+    }
+    if (stage2BottomDot) {
+        const repoBuildStatus =
+            workflowStatuses[WORKFLOW_IDS.REPO_BUILD] || "unknown";
+        setElementStatus(stage2BottomDot, repoBuildStatus);
+    }
+
+    // Stage 3: stacked dots for individual workflows
+    const stage3TopDot = document.getElementById("current-stage-3-top");
+    const stage3BottomDot = document.getElementById("current-stage-3-bottom");
+    if (stage3TopDot) {
+        const nightlyStatus =
+            workflowStatuses[WORKFLOW_IDS.NIGHTLY] || "unknown";
+        setElementStatus(stage3TopDot, nightlyStatus);
+    }
+    if (stage3BottomDot) {
+        const manualReleaseStatus =
+            workflowStatuses[WORKFLOW_IDS.MANUAL_RELEASE] || "unknown";
+        setElementStatus(stage3BottomDot, manualReleaseStatus);
+    }
+
+    // Stage 4: stacked dots for individual workflows
+    const stage4TopDot = document.getElementById("current-stage-4-top");
+    const stage4BottomDot = document.getElementById("current-stage-4-bottom");
+    if (stage4TopDot) {
+        const publishGhcrStatus =
+            workflowStatuses[WORKFLOW_IDS.PUBLISH_GHCR] || "unknown";
+        setElementStatus(stage4TopDot, publishGhcrStatus);
+    }
+    if (stage4BottomDot) {
+        const publishS3Status =
+            workflowStatuses[WORKFLOW_IDS.PUBLISH_S3] || "unknown";
+        setElementStatus(stage4BottomDot, publishS3Status);
     }
 
     // Update summary text

--- a/style.css
+++ b/style.css
@@ -112,6 +112,9 @@
     --shadow-md: 0 0.5rem 1rem var(--shadow-color-black-medium);
     --shadow-lg: 0 1rem 3rem var(--shadow-color-black-large);
 
+    /* Stage Dots Spacing */
+    --stage-dots-gap: 4px;
+
     /* Text Shadow */
     --text-shadow-header: 0 2px 4px var(--shadow-color-black-medium);
 }
@@ -123,9 +126,7 @@
 /* Status indicator dots - unified base class (remove current-overall-status to avoid conflicts) */
 .status-indicator,
 .current-status-indicator,
-.current-stage-dot,
-.stage-dot,
-.historic-stage-dot {
+.stage-dot {
     display: inline-block;
     width: 14px;
     height: 14px;
@@ -135,6 +136,21 @@
     box-shadow: 0 1px 3px var(--shadow-color-black);
     transition: all 0.3s ease;
     margin: 0 auto;
+    flex-shrink: 0;
+}
+
+/* Stage dots (both single and within stacked containers) */
+.current-stage-dot,
+.historic-stage-dot {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background-color: var(--color-unknown);
+    border: 2px solid var(--border-white-transparent);
+    box-shadow: 0 1px 3px var(--shadow-color-black);
+    transition: all 0.3s ease;
+    margin: 0;
     flex-shrink: 0;
 }
 
@@ -1060,9 +1076,27 @@ table {
 .current-stages,
 .historic-stages {
     display: flex;
-    gap: 4px;
+    gap: var(--stage-dots-gap);
     width: 70px;
     flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Single dot container for stage 1 */
+.current-stage-dot-container,
+.historic-stage-dot-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Stacked dots container for stages 2, 3, and 4 */
+.current-stage-dots-stacked,
+.historic-stage-dots-stacked {
+    display: flex;
+    flex-direction: column;
+    gap: var(--stage-dots-gap);
     align-items: center;
     justify-content: center;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In overview section add stacked dots for stages 2, 3, and 4.
Each dot represents an individual workflow status:
  - Stage 2: Repo Update (top), Repo Build (bottom)
  - Stage 3: Garden Linux Nightly - Schedule (top), Build and publish a release - Manual (bottom)
  - Stage 4: Publish to ghcr.io (top), Publish to S3 (bottom)

This makes it easier to identify which exact step failed.

Old:
<img width="1234" height="2066" alt="image" src="https://github.com/user-attachments/assets/fe8d5d2c-549e-4871-a6ad-aa4d0a3a6a9a" />

New:
<img width="1245" height="2069" alt="image" src="https://github.com/user-attachments/assets/b32889b5-87c8-4876-9c5b-cbe1fa39b123" />
