### PR TITLE
feat: add configurable historic releases count

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,12 @@
 
                 <h3>Historic Daily Releases</h3>
                 <div class="gl-selector">
+                    <small class="gl-description">
+                        Navigate to a specific Garden Linux version to view its
+                        daily release status, workflow runs, and package build
+                        information. Enter a version number below and click "Go
+                        to Version" to view that release.
+                    </small>
                     <label for="gl-input">Garden Linux Version:</label>
                     <div class="gl-input-group">
                         <button class="gl-btn" onclick="decrementGL()">
@@ -65,7 +71,6 @@
                             id="gl-input"
                             min="1"
                             step="1"
-                            onchange="goToGL()"
                             onkeypress="handleGLKeypress(event)"
                             oninput="handleGLInput()"
                         />
@@ -77,10 +82,58 @@
                         <small id="gl-date-info">Loading...</small>
                     </div>
                     <div class="gl-actions">
-                        <button onclick="goToToday()" class="today-btn">
+                        <button onclick="goToGL()" class="today-btn">
+                            Go to Version
+                        </button>
+                        <button
+                            onclick="goToToday()"
+                            class="today-btn"
+                            style="margin-top: 8px"
+                        >
                             Go to Today
                         </button>
                     </div>
+                </div>
+
+                <hr class="settings-separator" />
+
+                <h3>Historic Releases Settings</h3>
+                <div class="historic-count-settings">
+                    <div class="historic-count-group">
+                        <label for="historic-count-input"
+                            >Number of historic releases to show:</label
+                        >
+                        <div class="historic-count-input-group">
+                            <input
+                                type="number"
+                                id="historic-count-input"
+                                min="1"
+                                max="100"
+                                step="1"
+                                value="14"
+                                onchange="updateHistoricCount()"
+                                onkeypress="handleHistoricCountKeypress(event)"
+                            />
+                            <button
+                                onclick="updateHistoricCount()"
+                                class="gl-btn"
+                            >
+                                Apply
+                            </button>
+                        </div>
+                        <div class="historic-count-info">
+                            <small id="historic-count-info"
+                                >Default: 14 days</small
+                            >
+                        </div>
+                    </div>
+                    <small class="historic-count-help">
+                        Set how many historic daily releases to display in the
+                        historic releases section.
+                        <br />
+                        The value will be saved as a URL parameter and can be
+                        shared.
+                    </small>
                 </div>
 
                 <hr class="settings-separator" />

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -34,6 +34,7 @@ import {
     calculatePipelineStatus,
     processWorkflowRuns,
     getRepoBranchParameter,
+    getHistoricReleasesCount,
 } from "./utils.js";
 
 import {
@@ -1182,9 +1183,10 @@ export async function loadHistoricReleases() {
     loadingDiv.style.display = "block";
 
     try {
-        // Load data for the last 14 days (excluding current day)
+        // Load data for the specified number of days (excluding current day)
+        const historicCount = getHistoricReleasesCount();
         const historicPromises = [];
-        for (let i = 1; i <= UI_CONFIG.HISTORIC_RELEASES_COUNT; i++) {
+        for (let i = 1; i <= historicCount; i++) {
             const historicGL = baseGL - i;
             if (historicGL > 0) {
                 historicPromises.push(loadHistoricDay(historicGL));

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,7 @@ import {
     formatDetailedDateFromDate,
     isHistoricView,
     getWorkflowsByStage,
+    getHistoricReleasesCount,
 } from "./utils.js";
 
 import { generateWorkflowBoxHTML as uiGenerateWorkflowBoxHTML } from "./ui.js";
@@ -62,7 +63,7 @@ window.saveToken = function () {
         // Validate token format
         if (!token.startsWith("ghp_") && !token.startsWith("github_pat_")) {
             console.warn("[Main] Token save attempted with invalid format:", {
-                tokenPrefix: token.substring(0, 10) + "...",
+                tokenPrefix: `${token.substring(0, 10)}...`,
                 tokenLength: token.length,
             });
             const confirmSave = confirm(
@@ -105,6 +106,56 @@ window.clearToken = function () {
         alert("Failed to clear token. Please try again.");
     }
 };
+
+// ========================================
+// HISTORIC RELEASES COUNT SETTINGS
+// ========================================
+window.updateHistoricCount = function () {
+    const input = document.getElementById("historic-count-input");
+    if (!input) return;
+
+    const count = parseInt(input.value, 10);
+    if (isNaN(count) || count < 1 || count > 100) {
+        alert("Please enter a valid number between 1 and 100");
+        input.value = getHistoricReleasesCount();
+        return;
+    }
+
+    // Update URL parameter
+    const url = new URL(window.location);
+    if (count === 14) {
+        // Remove parameter if default value
+        url.searchParams.delete("historic_count");
+    } else {
+        url.searchParams.set("historic_count", count.toString());
+    }
+
+    // Navigate to the new URL
+    window.location.href = url.toString();
+};
+
+window.handleHistoricCountKeypress = function (event) {
+    if (event.key === "Enter") {
+        window.updateHistoricCount();
+    }
+};
+
+// Set historic count input from URL parameter
+function setHistoricCountFromUrl() {
+    const input = document.getElementById("historic-count-input");
+    if (!input) return;
+    const count = getHistoricReleasesCount();
+    input.value = count;
+    updateHistoricCountInfo();
+}
+
+// Update historic count info text
+function updateHistoricCountInfo() {
+    const infoElement = document.getElementById("historic-count-info");
+    if (!infoElement) return;
+    const count = getHistoricReleasesCount();
+    infoElement.textContent = `Currently showing: ${count} ${count === 1 ? "day" : "days"}`;
+}
 
 // ========================================
 // BRANCH SEARCH SETTINGS
@@ -170,9 +221,13 @@ function setBranchCheckboxFromUrl() {
 
 // Call this on DOMContentLoaded or after settings panel is rendered
 if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", setBranchCheckboxFromUrl);
+    document.addEventListener("DOMContentLoaded", () => {
+        setBranchCheckboxFromUrl();
+        setHistoricCountFromUrl();
+    });
 } else {
     setBranchCheckboxFromUrl();
+    setHistoricCountFromUrl();
 }
 
 function updateAuthStatus() {
@@ -233,7 +288,7 @@ window.handleGLKeypress = function (event) {
     if (event.key === "Enter") {
         goToGL();
     }
-    // Update date info as user types
+    // Update date info as user types (no navigation on input)
     setTimeout(() => {
         const glInput = document.getElementById("gl-input");
         const value = parseInt(glInput.value);
@@ -504,7 +559,8 @@ function initDashboard() {
                 ".historic-releases-header h2"
             );
             if (historicReleaseHeader) {
-                historicReleaseHeader.textContent = `📅 Historic Daily Releases (14 Days Before GL ${glDays})`;
+                const historicCount = getHistoricReleasesCount();
+                historicReleaseHeader.textContent = `📅 Historic Daily Releases (${historicCount} ${historicCount === 1 ? "Day" : "Days"} Before GL ${glDays})`;
             }
         } else {
             glDaysElement.innerText = `GL ${glDays} \n ${formattedDate}`;
@@ -530,7 +586,8 @@ function initDashboard() {
                 ".historic-releases-header h2"
             );
             if (historicReleaseHeader) {
-                historicReleaseHeader.textContent = `📅 Historic Daily Releases (14 Days Before Today)`;
+                const historicCount = getHistoricReleasesCount();
+                historicReleaseHeader.textContent = `📅 Historic Daily Releases (${historicCount} ${historicCount === 1 ? "Day" : "Days"} Before Today)`;
             }
         }
 
@@ -567,6 +624,7 @@ function initDashboard() {
         updateAuthStatus(); // Initialize auth status display
         initializeGLSelector(); // Initialize GL version selector
         generateWorkflowHTML(); // Generate workflow HTML
+        updateHistoricCountInfo(); // Update historic count info display
 
         console.log("[Main] Dashboard initialization completed successfully");
     } catch (error) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,6 +40,17 @@ export function getGlDaysFromUrl() {
     return null;
 }
 
+export function getHistoricReleasesCount() {
+    const countParam = getUrlParameter("historic_count");
+    if (countParam) {
+        const count = parseInt(countParam, 10);
+        if (!isNaN(count) && count > 0 && count <= 100) {
+            return count;
+        }
+    }
+    return 14; // Default value
+}
+
 export function getCurrentGlDays() {
     const today = new Date();
     today.setHours(0, 0, 0, 0);

--- a/style.css
+++ b/style.css
@@ -1636,6 +1636,14 @@ table {
     margin-bottom: 15px;
 }
 
+.gl-description {
+    display: block;
+    color: var(--text-unknown);
+    font-size: 0.8em;
+    margin-top: 0;
+    margin-bottom: 12px;
+}
+
 .gl-selector label {
     display: block;
     margin-bottom: 5px;
@@ -1703,6 +1711,9 @@ table {
 
 .gl-actions {
     margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 }
 
 .today-btn {
@@ -1718,12 +1729,66 @@ table {
     text-decoration: none;
     display: block;
     text-align: center;
+    margin-top: 0;
 }
 
 .today-btn:hover {
     background: var(--color-success-dark);
     border-color: var(--color-success-dark);
     transform: translateY(-1px);
+}
+
+/* HISTORIC COUNT SETTINGS */
+.historic-count-settings {
+    margin-bottom: 15px;
+}
+
+.historic-count-group {
+    margin-bottom: 10px;
+}
+
+.historic-count-group label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 500;
+    color: var(--text-primary);
+    font-size: 0.9em;
+}
+
+.historic-count-input-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+#historic-count-input {
+    flex: 1;
+    padding: 6px 8px;
+    border: 1px solid var(--border-medium);
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-family: monospace;
+    background: var(--bg-unknown);
+    color: var(--text-primary);
+}
+
+#historic-count-input:focus {
+    outline: none;
+    border-color: var(--color-info);
+    box-shadow: 0 0 0 2px var(--shadow-color-info-light);
+}
+
+.historic-count-info {
+    font-size: 0.8em;
+    color: var(--text-unknown);
+}
+
+.historic-count-help {
+    display: block;
+    color: var(--text-unknown);
+    font-size: 0.8em;
+    margin-top: 5px;
 }
 
 /* SEQUENTIAL WORKFLOWS & SUB-STAGES */


### PR DESCRIPTION
**What this PR does / why we need it**:

Add option to configure how many historic daily releases are displayed. The count can be set via settings panel or URL parameter (historic_count). Default remains 14 days.

<img width="358" height="1160" alt="image" src="https://github.com/user-attachments/assets/733f8b0b-bd05-4dce-b9a3-873793db7128" />
