### PR TITLE
Feat/deprecate stage4

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,6 +262,7 @@
                                     class="current-stage-dots-stacked"
                                     id="current-stage-4-container"
                                     title="Publish"
+                                    data-stage-version="v1"
                                 >
                                     <span
                                         class="current-stage-dot unknown"
@@ -321,8 +322,12 @@
                         id="pipeline-stages-container"
                     >
                         <div class="pipeline-container" id="pipeline-container">
-                            <!-- Stage 4: Publish Images -->
-                            <div class="pipeline-stage stage-4" id="stage-4">
+                            <!-- Stage 4: Publish Images (schema v1 only) -->
+                            <div
+                                class="pipeline-stage stage-4"
+                                id="stage-4"
+                                data-stage-version="v1"
+                            >
                                 <div class="stage-header">
                                     <span class="stage-icon">🚀</span>
                                     <h3>Stage 4: Publish Images</h3>

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,30 @@
 export const GL_INITIAL_DATE = "2020-03-31";
 
 // ========================================
+// SCHEMA VERSION CONFIGURATION
+// ========================================
+// Schema v2 starts at GL 2174 - no more stage 4 (Publish Images)
+export const SCHEMA_V2_CUTOFF = 2174;
+
+/**
+ * Determines the schema version based on GL days
+ * @param {number} glDays - Garden Linux version number
+ * @returns {number} Schema version (1 or 2)
+ */
+export function getSchemaVersion(glDays) {
+    return glDays >= SCHEMA_V2_CUTOFF ? 2 : 1;
+}
+
+/**
+ * Checks if a GL version has stage 4 (Publish Images)
+ * @param {number} glDays - Garden Linux version number
+ * @returns {boolean} True if this version has stage 4
+ */
+export function hasStage4(glDays) {
+    return glDays < SCHEMA_V2_CUTOFF;
+}
+
+// ========================================
 // ARTIFACT CONFIGURATION
 // ========================================
 
@@ -115,6 +139,28 @@ export const STAGE_WORKFLOWS = {
     "stage-4": [WORKFLOW_IDS.PUBLISH_GHCR, WORKFLOW_IDS.PUBLISH_S3],
 };
 
+/**
+ * Gets stage workflows based on schema version
+ * @param {number} glDays - Garden Linux version number
+ * @returns {Object} Stage to workflow ID mappings
+ */
+export function getStageWorkflows(glDays) {
+    const baseStages = {
+        "stage-1": [], // Package Builds (handled separately)
+        "stage-2": [WORKFLOW_IDS.REPO_UPDATE, WORKFLOW_IDS.REPO_BUILD],
+        "stage-3": [WORKFLOW_IDS.NIGHTLY, WORKFLOW_IDS.MANUAL_RELEASE],
+    };
+
+    if (hasStage4(glDays)) {
+        baseStages["stage-4"] = [
+            WORKFLOW_IDS.PUBLISH_GHCR,
+            WORKFLOW_IDS.PUBLISH_S3,
+        ];
+    }
+
+    return baseStages;
+}
+
 // All expected workflow IDs for validation
 export const EXPECTED_WORKFLOW_IDS = [
     WORKFLOW_IDS.REPO_UPDATE,
@@ -124,6 +170,26 @@ export const EXPECTED_WORKFLOW_IDS = [
     WORKFLOW_IDS.PUBLISH_GHCR,
     WORKFLOW_IDS.PUBLISH_S3,
 ];
+
+/**
+ * Gets expected workflow IDs based on schema version
+ * @param {number} glDays - Garden Linux version number
+ * @returns {Array<string>} Array of workflow IDs
+ */
+export function getExpectedWorkflowIds(glDays) {
+    const base = [
+        WORKFLOW_IDS.REPO_UPDATE,
+        WORKFLOW_IDS.REPO_BUILD,
+        WORKFLOW_IDS.NIGHTLY,
+        WORKFLOW_IDS.MANUAL_RELEASE,
+    ];
+
+    if (hasStage4(glDays)) {
+        base.push(WORKFLOW_IDS.PUBLISH_GHCR, WORKFLOW_IDS.PUBLISH_S3);
+    }
+
+    return base;
+}
 
 // ========================================
 // API CONFIGURATION

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -46,6 +46,8 @@ import {
     API_CONFIG,
     PACKAGE_STATUSES,
     UI_CONFIG,
+    getStageWorkflows,
+    getExpectedWorkflowIds,
 } from "./constants.js";
 
 import {
@@ -127,9 +129,6 @@ function updateWorkflowMonitoringHeader() {
 // WORKFLOW STATUS MANAGEMENT
 // ========================================
 export async function getRun() {
-    // Use workflow configurations from constants
-    getAllWorkflowConfigs();
-
     // Reset workflow statuses
     workflowStatuses = {};
     workflowRunData = {};
@@ -157,13 +156,14 @@ export async function getRun() {
 
     // Process workflows in two phases:
     // Phase 1: Process Stage 3 workflows first to collect run IDs
-    // Phase 2: Process all other workflows (including Stage 4 with parent matching)
+    // Phase 2: Process all other workflows (including Stage 4 with parent matching if schema v1)
 
     const stage3WorkflowIds = [
         WORKFLOW_IDS.NIGHTLY,
         WORKFLOW_IDS.MANUAL_RELEASE,
     ];
-    const allWorkflows = getAllWorkflowConfigs();
+    // Get version-aware workflows (excludes stage-4 for schema v2)
+    const allWorkflows = getAllWorkflowConfigs(glDays);
     const stage3Workflows = allWorkflows.filter((w) =>
         stage3WorkflowIds.includes(w.id)
     );
@@ -1087,11 +1087,15 @@ export function updatePipelineHierarchy() {
     console.log("Workflow statuses:", workflowStatuses);
     console.log("Package status:", packageStatus);
 
+    // Get GL version to use version-aware stage workflows
+    const glDays = getGlDays();
+    const versionAwareStageWorkflows = getStageWorkflows(glDays);
+
     // Use shared stage status calculation (same as current view)
     const stageStatuses = calculateStageStatuses(
         workflowStatuses,
         packageStatus,
-        STAGE_WORKFLOWS
+        versionAwareStageWorkflows
     );
 
     console.log(`[Current View] Stage statuses:`, stageStatuses);
@@ -1105,15 +1109,16 @@ export function updatePipelineHierarchy() {
     // Use shared pipeline status calculation (same as current view)
     const pipelineStatus = calculatePipelineStatus(stageStatuses);
 
-    // Count expected vs actual workflow statuses for logging
-    const loadedWorkflowStatuses = EXPECTED_WORKFLOW_IDS.filter(
+    // Count expected vs actual workflow statuses for logging (version-aware)
+    const expectedWorkflowIds = getExpectedWorkflowIds(glDays);
+    const loadedWorkflowStatuses = expectedWorkflowIds.filter(
         (id) => workflowStatuses[id] && workflowStatuses[id] !== "unknown"
     );
     const allWorkflowsLoaded =
-        loadedWorkflowStatuses.length === EXPECTED_WORKFLOW_IDS.length;
+        loadedWorkflowStatuses.length === expectedWorkflowIds.length;
 
     console.log("Pipeline status evaluation:");
-    console.log("- Expected workflows:", EXPECTED_WORKFLOW_IDS.length);
+    console.log("- Expected workflows:", expectedWorkflowIds.length);
     console.log("- Loaded workflows:", loadedWorkflowStatuses.length);
     console.log("- All workflows loaded:", allWorkflowsLoaded);
     console.log("- Stage statuses:", Object.values(stageStatuses));
@@ -1244,20 +1249,22 @@ async function loadHistoricDay(glDays) {
         const { workflowStatuses, workflowRunData } =
             await getHistoricWorkflowStatuses(glDays);
 
-        // Use shared stage status calculation (same as current view)
+        // Use shared stage status calculation with version-aware stages
+        const versionAwareStageWorkflows = getStageWorkflows(glDays);
         const stageStatuses = calculateStageStatuses(
             workflowStatuses,
             packageStatus.status,
-            STAGE_WORKFLOWS
+            versionAwareStageWorkflows
         );
 
         // Use shared pipeline status calculation (same as current view)
         const pipelineStatus = calculatePipelineStatus(stageStatuses);
 
-        // Calculate pipeline duration
+        // Calculate pipeline duration (version-aware)
         const duration = calculateHistoricPipelineDuration(
             workflowRunData,
-            WORKFLOW_IDS
+            WORKFLOW_IDS,
+            glDays
         );
 
         return {
@@ -1339,50 +1346,16 @@ async function getHistoricWorkflowStatuses(glDays) {
     extendedNextDay.setDate(extendedNextDay.getDate() + 1);
 
     try {
-        // Check multiple workflows per stage for better coverage using constants
-        const workflowChecks = [
-            // Stage 2: Repository workflows
-            {
-                id: WORKFLOW_IDS.REPO_UPDATE,
-                stage: "stage-2",
-                repo: WORKFLOWS.REPO_UPDATE.repo,
-                name: WORKFLOWS.REPO_UPDATE.name,
-            },
-            {
-                id: WORKFLOW_IDS.REPO_BUILD,
-                stage: "stage-2",
-                repo: WORKFLOWS.REPO_BUILD.repo,
-                name: WORKFLOWS.REPO_BUILD.name,
-            },
-
-            // Stage 3: Build & Release workflows
-            {
-                id: WORKFLOW_IDS.NIGHTLY,
-                stage: "stage-3",
-                repo: WORKFLOWS.NIGHTLY.repo,
-                name: WORKFLOWS.NIGHTLY.name,
-            },
-            {
-                id: WORKFLOW_IDS.MANUAL_RELEASE,
-                stage: "stage-3",
-                repo: WORKFLOWS.MANUAL_RELEASE.repo,
-                name: WORKFLOWS.MANUAL_RELEASE.name,
-            },
-
-            // Stage 4: Publish workflows
-            {
-                id: WORKFLOW_IDS.PUBLISH_GHCR,
-                stage: "stage-4",
-                repo: WORKFLOWS.PUBLISH_GHCR.repo,
-                name: WORKFLOWS.PUBLISH_GHCR.name,
-            },
-            {
-                id: WORKFLOW_IDS.PUBLISH_S3,
-                stage: "stage-4",
-                repo: WORKFLOWS.PUBLISH_S3.repo,
-                name: WORKFLOWS.PUBLISH_S3.name,
-            },
-        ];
+        // Use version-aware workflow list (excludes stage-4 for schema v2)
+        const allWorkflowsForVersion = getAllWorkflowConfigs(glDays);
+        const workflowChecks = allWorkflowsForVersion
+            .map((w) => ({
+                id: w.id,
+                stage: w.stage,
+                repo: w.repo,
+                name: w.name,
+            }))
+            .filter((w) => w.stage.startsWith("stage-")); // Only include stage workflows
 
         // Collect Stage 3 run IDs first
         const stage3Workflows = workflowChecks.filter(

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,7 @@ import {
     GL_INITIAL_DATE,
     API_CONFIG,
     WORKFLOWS,
+    hasStage4,
 } from "./constants.js";
 
 import {
@@ -403,15 +404,27 @@ function toggleCloudCleanup() {
 function generateWorkflowHTML() {
     console.log("Generating workflow HTML from constants...");
 
-    // Stage 4: Publish Images
-    const stage4Workflows = getWorkflowsByStage("stage-4");
-    const stage4Container = document.querySelector("#stage-4 .stage-workflows");
-    if (stage4Container && stage4Workflows.length > 0) {
-        stage4Container.innerHTML = stage4Workflows
-            .map((workflow) =>
-                uiGenerateWorkflowBoxHTML(workflow, API_CONFIG, WORKFLOWS)
-            )
-            .join("");
+    const glDays = getGlDays();
+
+    // Stage 4: Publish Images (only for schema v1)
+    if (hasStage4(glDays)) {
+        const stage4Workflows = getWorkflowsByStage("stage-4");
+        const stage4Container = document.querySelector(
+            "#stage-4 .stage-workflows"
+        );
+        if (stage4Container && stage4Workflows.length > 0) {
+            stage4Container.innerHTML = stage4Workflows
+                .map((workflow) =>
+                    uiGenerateWorkflowBoxHTML(workflow, API_CONFIG, WORKFLOWS)
+                )
+                .join("");
+        }
+    } else {
+        // Hide stage 4 for schema v2
+        const stage4Element = document.getElementById("stage-4");
+        if (stage4Element) {
+            stage4Element.style.display = "none";
+        }
     }
 
     // Stage 3: Build & Release Images

--- a/src/parentWorkflow.js
+++ b/src/parentWorkflow.js
@@ -129,6 +129,30 @@ export async function downloadAndExtractArtifact(owner, repo, artifact) {
  */
 export async function getParentWorkflowInfo(owner, repo, runId) {
     try {
+        // First, try to get parent workflow info from the workflow_run event
+        // This is more reliable and doesn't require downloading artifacts
+        const runResponse = await fetch(
+            `${API_CONFIG.GITHUB_API_BASE}/repos/${owner}/${repo}/actions/runs/${runId}`,
+            {
+                headers: getAuthHeaders(),
+            }
+        );
+
+        if (runResponse.ok) {
+            const run = await runResponse.json();
+
+            // Check for parent workflow run ID in workflow_run event
+            if (run.event === "workflow_run" && run.workflow_run?.id) {
+                return {
+                    found: true,
+                    message: "Parent run ID detected from workflow_run event",
+                    parentRunId: run.workflow_run.id.toString(),
+                    extractionMethod: "workflow_run_event",
+                };
+            }
+        }
+
+        // Fall back to artifact-based detection if workflow_run event doesn't provide parent info
         const artifactsResponse = await fetch(
             `${API_CONFIG.GITHUB_API_BASE}/repos/${owner}/${repo}/actions/runs/${runId}/artifacts`,
             {

--- a/src/ui.js
+++ b/src/ui.js
@@ -22,7 +22,7 @@ import {
     formatDateTimeDetailed,
     getTriggerInfo,
 } from "./utils.js";
-import { WORKFLOW_IDS, API_CONFIG } from "./constants.js";
+import { WORKFLOW_IDS, API_CONFIG, hasStage4 } from "./constants.js";
 import { getParentWorkflowInfo } from "./parentWorkflow.js";
 
 // Render the historic releases section
@@ -85,6 +85,12 @@ export function renderHistoricReleases(historicData) {
                     ? day.workflowStatuses[WORKFLOW_IDS.PUBLISH_S3]
                     : "unknown";
 
+            // Determine if this day has stage 4 based on its GL version
+            const dayHasStage4 = hasStage4(day.glDays);
+            const stageTitle = dayHasStage4
+                ? "Stages: Package | Repo | Build | Publish"
+                : "Stages: Package | Repo | Build";
+
             return `
         <a href="?gl=${day.glDays}&no_historic_releases=true" target="_blank" class="historic-release-row ${day.pipelineStatus}" title="View detailed dashboard for GL ${day.glDays}">
             <div class="historic-gl-version ${day.pipelineStatus}">GL ${day.glDays}</div>
@@ -95,7 +101,7 @@ export function renderHistoricReleases(historicData) {
                       title="Overall Status: ${day.pipelineStatus}"></span>
             </div>
 
-            <div class="historic-stages" title="Stages: Package | Repo | Build | Publish">
+            <div class="historic-stages" title="${stageTitle}">
                 <div class="historic-stage-dot-container" title="Package Builds">
                     <span class="historic-stage-dot ${day.workflowStatus && day.workflowStatus["stage-1"] ? day.workflowStatus["stage-1"] : "unknown"}" title="Package Builds"></span>
                 </div>
@@ -107,10 +113,16 @@ export function renderHistoricReleases(historicData) {
                     <span class="historic-stage-dot ${nightlyStatus}" title="Garden Linux Nightly - Schedule"></span>
                     <span class="historic-stage-dot ${manualReleaseStatus}" title="Build and publish a release - Manual"></span>
                 </div>
+                ${
+                    dayHasStage4
+                        ? `
                 <div class="historic-stage-dots-stacked" title="Publish">
                     <span class="historic-stage-dot ${publishGhcrStatus}" title="Publish to ghcr.io"></span>
                     <span class="historic-stage-dot ${publishS3Status}" title="Publish to S3"></span>
                 </div>
+                `
+                        : ""
+                }
             </div>
 
             <div class="historic-package-status">
@@ -130,7 +142,7 @@ export function renderHistoricReleases(historicData) {
                 }
             </div>
 
-            <div class="historic-duration" title="Duration of stages 3 and 4">
+            <div class="historic-duration" title="${dayHasStage4 ? "Duration of stages 3 and 4" : "Duration of stage 3"}">
                 ${day.duration || "No data"}
             </div>
 
@@ -243,18 +255,30 @@ export function updateCurrentReleaseSummary(
         setElementStatus(stage3BottomDot, manualReleaseStatus);
     }
 
-    // Stage 4: stacked dots for individual workflows
-    const stage4TopDot = document.getElementById("current-stage-4-top");
-    const stage4BottomDot = document.getElementById("current-stage-4-bottom");
-    if (stage4TopDot) {
-        const publishGhcrStatus =
-            workflowStatuses[WORKFLOW_IDS.PUBLISH_GHCR] || "unknown";
-        setElementStatus(stage4TopDot, publishGhcrStatus);
-    }
-    if (stage4BottomDot) {
-        const publishS3Status =
-            workflowStatuses[WORKFLOW_IDS.PUBLISH_S3] || "unknown";
-        setElementStatus(stage4BottomDot, publishS3Status);
+    // Stage 4: stacked dots for individual workflows (only for schema v1)
+    if (hasStage4(glDays)) {
+        const stage4TopDot = document.getElementById("current-stage-4-top");
+        const stage4BottomDot = document.getElementById(
+            "current-stage-4-bottom"
+        );
+        if (stage4TopDot) {
+            const publishGhcrStatus =
+                workflowStatuses[WORKFLOW_IDS.PUBLISH_GHCR] || "unknown";
+            setElementStatus(stage4TopDot, publishGhcrStatus);
+        }
+        if (stage4BottomDot) {
+            const publishS3Status =
+                workflowStatuses[WORKFLOW_IDS.PUBLISH_S3] || "unknown";
+            setElementStatus(stage4BottomDot, publishS3Status);
+        }
+    } else {
+        // Hide stage 4 container for schema v2
+        const stage4Container = document.getElementById(
+            "current-stage-4-container"
+        );
+        if (stage4Container) {
+            stage4Container.style.display = "none";
+        }
     }
 
     // Update summary text
@@ -306,10 +330,14 @@ export function updateCurrentReleaseSummary(
             stageStatuses,
             pipelineStatus,
             workflowRunData,
-            WORKFLOW_IDS
+            WORKFLOW_IDS,
+            glDays
         );
         currentDurationElement.textContent = duration;
-        currentDurationElement.title = "Duration of stages 3 and 4";
+        // Update tooltip based on schema version
+        currentDurationElement.title = hasStage4(glDays)
+            ? "Duration of stages 3 and 4"
+            : "Duration of stage 3";
     }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,12 @@
  * Core support library used across all dashboard components.
  */
 
-import { GL_INITIAL_DATE, WORKFLOWS } from "./constants.js";
+import {
+    GL_INITIAL_DATE,
+    WORKFLOWS,
+    hasStage4,
+    SCHEMA_V2_CUTOFF,
+} from "./constants.js";
 
 // ========================================
 // DATE AND GL VERSION CALCULATIONS
@@ -440,16 +445,12 @@ export function calculatePipelineDuration(
     stageStatuses,
     pipelineStatus,
     workflowRunData,
-    WORKFLOW_IDS
+    WORKFLOW_IDS,
+    glDays
 ) {
-    // Always try to calculate actual duration from Stage 3 to Stage 4 first
     const stage3Workflows = [WORKFLOW_IDS.NIGHTLY, WORKFLOW_IDS.MANUAL_RELEASE];
-    const stage4Workflows = [
-        WORKFLOW_IDS.PUBLISH_GHCR,
-        WORKFLOW_IDS.PUBLISH_S3,
-    ];
     let earliestStage3Start = null;
-    let latestStage4End = null;
+    let latestEndTime = null;
     let hasInProgressWorkflows = false;
 
     // Find earliest Stage 3 start time and check for in-progress workflows
@@ -479,22 +480,43 @@ export function calculatePipelineDuration(
         }
     }
 
-    // Find latest Stage 4 end time
-    for (const workflowId of stage4Workflows) {
-        if (workflowRunData && workflowRunData[workflowId]) {
-            const runData = workflowRunData[workflowId];
-            if (runData.status === "completed") {
-                const endTime = new Date(runData.updated_at);
-                if (!latestStage4End || endTime > latestStage4End) {
-                    latestStage4End = endTime;
+    // Schema v2 (GL >= 2174): Duration is Stage 3 only
+    // Schema v1 (GL < 2174): Duration is Stage 3 start → Stage 4 end
+    if (hasStage4(glDays)) {
+        // v1: Find latest Stage 4 end time
+        const stage4Workflows = [
+            WORKFLOW_IDS.PUBLISH_GHCR,
+            WORKFLOW_IDS.PUBLISH_S3,
+        ];
+        for (const workflowId of stage4Workflows) {
+            if (workflowRunData && workflowRunData[workflowId]) {
+                const runData = workflowRunData[workflowId];
+                if (runData.status === "completed") {
+                    const endTime = new Date(runData.updated_at);
+                    if (!latestEndTime || endTime > latestEndTime) {
+                        latestEndTime = endTime;
+                    }
+                }
+            }
+        }
+    } else {
+        // v2: Find latest Stage 3 end time
+        for (const workflowId of stage3Workflows) {
+            if (workflowRunData && workflowRunData[workflowId]) {
+                const runData = workflowRunData[workflowId];
+                if (runData.status === "completed") {
+                    const endTime = new Date(runData.updated_at);
+                    if (!latestEndTime || endTime > latestEndTime) {
+                        latestEndTime = endTime;
+                    }
                 }
             }
         }
     }
 
     // Calculate duration if we have both start and end times
-    if (earliestStage3Start && latestStage4End) {
-        const durationMs = latestStage4End - earliestStage3Start;
+    if (earliestStage3Start && latestEndTime) {
+        const durationMs = latestEndTime - earliestStage3Start;
         if (durationMs > 0) {
             const durationHours = Math.floor(durationMs / 3600000);
             const durationMinutes = Math.floor((durationMs % 3600000) / 60000);
@@ -532,15 +554,12 @@ export function calculateTargetDate(glDays, GL_INITIAL_DATE) {
 
 export function calculateHistoricPipelineDuration(
     workflowRunData,
-    WORKFLOW_IDS
+    WORKFLOW_IDS,
+    glDays
 ) {
     const stage3Workflows = [WORKFLOW_IDS.NIGHTLY, WORKFLOW_IDS.MANUAL_RELEASE];
-    const stage4Workflows = [
-        WORKFLOW_IDS.PUBLISH_GHCR,
-        WORKFLOW_IDS.PUBLISH_S3,
-    ];
     let earliestStage3Start = null;
-    let latestStage4End = null;
+    let latestEndTime = null;
 
     // Find earliest Stage 3 start time
     for (const workflowId of stage3Workflows) {
@@ -559,22 +578,43 @@ export function calculateHistoricPipelineDuration(
         }
     }
 
-    // Find latest Stage 4 end time (only from completed workflows for historic data)
-    for (const workflowId of stage4Workflows) {
-        if (workflowRunData && workflowRunData[workflowId]) {
-            const runData = workflowRunData[workflowId];
-            if (runData.status === "completed") {
-                const endTime = new Date(runData.updated_at);
-                if (!latestStage4End || endTime > latestStage4End) {
-                    latestStage4End = endTime;
+    // Schema v2 (GL >= 2174): Duration is Stage 3 only
+    // Schema v1 (GL < 2174): Duration is Stage 3 start → Stage 4 end
+    if (hasStage4(glDays)) {
+        // v1: Find latest Stage 4 end time (only from completed workflows for historic data)
+        const stage4Workflows = [
+            WORKFLOW_IDS.PUBLISH_GHCR,
+            WORKFLOW_IDS.PUBLISH_S3,
+        ];
+        for (const workflowId of stage4Workflows) {
+            if (workflowRunData && workflowRunData[workflowId]) {
+                const runData = workflowRunData[workflowId];
+                if (runData.status === "completed") {
+                    const endTime = new Date(runData.updated_at);
+                    if (!latestEndTime || endTime > latestEndTime) {
+                        latestEndTime = endTime;
+                    }
+                }
+            }
+        }
+    } else {
+        // v2: Find latest Stage 3 end time
+        for (const workflowId of stage3Workflows) {
+            if (workflowRunData && workflowRunData[workflowId]) {
+                const runData = workflowRunData[workflowId];
+                if (runData.status === "completed") {
+                    const endTime = new Date(runData.updated_at);
+                    if (!latestEndTime || endTime > latestEndTime) {
+                        latestEndTime = endTime;
+                    }
                 }
             }
         }
     }
 
     // Calculate duration if we have both start and end times
-    if (earliestStage3Start && latestStage4End) {
-        const durationMs = latestStage4End - earliestStage3Start;
+    if (earliestStage3Start && latestEndTime) {
+        const durationMs = latestEndTime - earliestStage3Start;
         if (durationMs > 0) {
             const durationHours = Math.floor(durationMs / 3600000);
             const durationMinutes = Math.floor((durationMs % 3600000) / 60000);
@@ -807,8 +847,20 @@ export async function collectStage3RunIds(
 // ========================================
 // HELPER FUNCTIONS FOR WORKFLOW ACCESS
 // ========================================
-export function getAllWorkflowConfigs() {
-    return Object.values(WORKFLOWS);
+export function getAllWorkflowConfigs(glDays = null) {
+    const allWorkflows = Object.values(WORKFLOWS);
+
+    // If no GL version specified, return all workflows (backward compatible)
+    if (glDays === null) {
+        return allWorkflows;
+    }
+
+    // Filter out stage-4 workflows for schema v2
+    if (!hasStage4(glDays)) {
+        return allWorkflows.filter((w) => w.stage !== "stage-4");
+    }
+
+    return allWorkflows;
 }
 
 export function getWorkflowsByStage(stageId) {
@@ -825,7 +877,7 @@ export function getWorkflowsByStage(stageId) {
  * Calculates stage statuses from workflow statuses using the same logic as current view
  * @param {Object} workflowStatuses - Object mapping workflow IDs to their statuses
  * @param {string} packageStatus - Package status (success, warning, failure, etc.)
- * @param {Object} STAGE_WORKFLOWS - Stage to workflow ID mappings
+ * @param {Object} STAGE_WORKFLOWS - Stage to workflow ID mappings (version-aware)
  * @returns {Object} Stage statuses object
  */
 export function calculateStageStatuses(
@@ -833,6 +885,8 @@ export function calculateStageStatuses(
     packageStatus,
     STAGE_WORKFLOWS
 ) {
+    // Note: STAGE_WORKFLOWS should already be version-aware from getStageWorkflows(glDays)
+    // This function works with whatever stages are passed in
     const stageStatuses = {};
 
     // Stage 1: Package status (map package status values to stage dot CSS classes)
@@ -964,8 +1018,8 @@ export async function processWorkflowRuns(
 
     let targetRuns = [];
 
-    if (isStage4Workflow) {
-        // For Stage 4: Use the shared validation logic
+    if (isStage4Workflow && hasStage4(glDays)) {
+        // For Stage 4 in schema v1: Use the shared validation logic
         targetRuns = await validateStage4Runs(
             runs,
             targetDate,


### PR DESCRIPTION
**What this PR does / why we need it**:

    feat: implement schema v2 - remove stage 4 for releases >= GL 2174
    
    Since release GL 2174, the pipeline no longer includes Stage 4 (Publish Images).
    This commit introduces version-aware schema handling to support both legacy and
    new pipeline structures.
    
    Changes:
    - Add schema v2 constants and version detection (SCHEMA_V2_CUTOFF = 2174)
    - Implement hasStage4() helper to determine schema version by GL days
    - Add version-aware getStageWorkflows() and getExpectedWorkflowIds()
    - Update duration calculations to use stage 3 end for v2 (instead of stage 4)
    - Modify workflow processing to skip stage-4 validation for v2
    - Update UI to conditionally show/hide stage 4 elements:
      * Current release summary dots
      * Pipeline details section
      * Historic release list (per-row based on each day's version)
    - Adjust duration tooltips ("Stage 3" vs "Stages 3 and 4")
    - Add data-stage-version attributes to HTML elements for v1-only content
    
    Schema v1 (GL < 2174): Stages 1, 2, 3, 4
    Schema v2 (GL >= 2174): Stages 1, 2, 3
    
    The implementation is backward compatible (historic data shows stage 4 when it
    existed) and automatically adapts the UI based on the GL version being viewed.
    Overall pipeline status now only considers existing stages.

### before

<img width="1276" height="1979" alt="image" src="https://github.com/user-attachments/assets/b6226372-fe73-44cd-a02c-067dd15d7f0a" />



### after
<img width="1276" height="1979" alt="image" src="https://github.com/user-attachments/assets/a7a80862-2b4d-409d-8ac1-75331c43ac92" />


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/daily/issues/53

**Special notes for your reviewer**:

Needs https://github.com/gardenlinux/daily/pull/40 and https://github.com/gardenlinux/daily/pull/41 merged first.
