### PR TITLE
fix: Add client-side branch filtering to prevent wrong workflow runs from displaying

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -25,6 +25,9 @@ export const GL_INITIAL_DATE = "2020-03-31";
 // Schema v2 starts at GL 2174 - no more stage 4 (Publish Images)
 export const SCHEMA_V2_CUTOFF = 2174;
 
+// Version format cutoff: Versions >= 2017 use X.Y.Z format, versions < 2017 use X.Y format
+export const VERSION_FORMAT_CUTOFF = 2017;
+
 /**
  * Determines the schema version based on GL days
  * @param {number} glDays - Garden Linux version number
@@ -32,6 +35,26 @@ export const SCHEMA_V2_CUTOFF = 2174;
  */
 export function getSchemaVersion(glDays) {
     return glDays >= SCHEMA_V2_CUTOFF ? 2 : 1;
+}
+
+/**
+ * Determines the version format based on GL days
+ * Versions < 2017.0.0 use major.minor format (e.g., "27.0", "1592.6")
+ * Versions >= 2017.0.0 use major.minor.patch format (e.g., "2017.0.0", "2222.1.5")
+ * @param {number} glDays - Garden Linux version number
+ * @returns {string} "X.Y" or "X.Y.Z" format specifier
+ */
+export function getVersionFormat(glDays) {
+    return glDays >= VERSION_FORMAT_CUTOFF ? "X.Y.Z" : "X.Y";
+}
+
+/**
+ * Formats a GL version number as a branch name according to versioning scheme
+ * @param {number} glDays - Garden Linux version number
+ * @returns {string} Branch name (e.g., "2179.0.0" or "1592.0")
+ */
+export function formatVersionBranch(glDays) {
+    return glDays >= VERSION_FORMAT_CUTOFF ? `${glDays}.0.0` : `${glDays}.0`;
 }
 
 /**

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -26,6 +26,7 @@ import {
     shouldLoadHistoricReleases,
     setElementStatus,
     getBranchParameter,
+    shouldSearchAllBranches,
     calculateTargetDate,
     calculateHistoricPipelineDuration,
     collectStage3RunIds,
@@ -47,6 +48,7 @@ import {
     PACKAGE_STATUSES,
     UI_CONFIG,
     getStageWorkflows,
+    formatVersionBranch,
     getExpectedWorkflowIds,
 } from "./constants.js";
 
@@ -186,7 +188,8 @@ export async function getRun() {
             extendedNextDay,
             stage3RunIds,
             tagName,
-            true
+            true,
+            glDays
         );
     }
 
@@ -202,7 +205,8 @@ export async function getRun() {
             extendedNextDay,
             stage3RunIds,
             tagName,
-            false
+            false,
+            glDays
         );
     }
 
@@ -219,7 +223,8 @@ async function processWorkflow(
     extendedNextDay,
     stage3RunIds,
     tagName,
-    _isStage3Phase
+    _isStage3Phase,
+    glDays
 ) {
     let apiUrl;
     const isCloudCleanup = workflow.id === WORKFLOW_IDS.CLOUD_TEST_CLEANUP;
@@ -652,6 +657,59 @@ async function processWorkflow(
             const runDate = new Date(run.created_at);
             return runDate >= targetDate && runDate < nextDay;
         });
+    }
+
+    // Filter by branch based on workflow type
+    // - Repo workflows: match version branch (e.g., "2179.0" for GL 2179)
+    // - Other workflows: only "main" branch
+    // - Skip filtering if "search all branches" is enabled
+    if (!shouldSearchAllBranches() && targetRunsUnsorted.length > 0) {
+        const beforeFilter = targetRunsUnsorted.length;
+
+        if (isRepoBuild) {
+            // Repo Build workflow runs on version branches
+            // Version format v1 (GL < 2017): "1592.0"
+            // Version format v2 (GL >= 2017): "2179.0.0"
+            const expectedBranch = formatVersionBranch(glDays);
+            targetRunsUnsorted = targetRunsUnsorted.filter((run) => {
+                const isCorrectBranch = run.head_branch === expectedBranch;
+                if (!isCorrectBranch) {
+                    console.log(
+                        `🔍 [Branch Filter] ${workflow.name}: Filtered out run #${run.run_number} from branch "${run.head_branch}" (expected "${expectedBranch}")`
+                    );
+                }
+                return isCorrectBranch;
+            });
+        } else if (isRepoUpdate) {
+            // Repo Update workflow always runs on main branch
+            targetRunsUnsorted = targetRunsUnsorted.filter((run) => {
+                const isMainBranch = run.head_branch === "main";
+                if (!isMainBranch) {
+                    console.log(
+                        `🔍 [Branch Filter] ${workflow.name}: Filtered out run #${run.run_number} from branch "${run.head_branch}" (expected "main")`
+                    );
+                }
+                return isMainBranch;
+            });
+        } else {
+            // Non-repo workflows run on main branch
+            targetRunsUnsorted = targetRunsUnsorted.filter((run) => {
+                const isMainBranch = run.head_branch === "main";
+                if (!isMainBranch) {
+                    console.log(
+                        `🔍 [Branch Filter] ${workflow.name}: Filtered out run #${run.run_number} from branch "${run.head_branch}" (expected "main")`
+                    );
+                }
+                return isMainBranch;
+            });
+        }
+
+        const afterFilter = targetRunsUnsorted.length;
+        if (beforeFilter !== afterFilter) {
+            console.log(
+                `🔍 [Branch Filter] ${workflow.name}: Filtered ${beforeFilter - afterFilter} runs from incorrect branches (${afterFilter} remaining)`
+            );
+        }
     }
 
     // Collect Stage 3 run IDs for later Stage 4 matching

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,6 +23,7 @@ import {
     WORKFLOWS,
     hasStage4,
     SCHEMA_V2_CUTOFF,
+    formatVersionBranch,
 } from "./constants.js";
 
 // ========================================
@@ -1035,6 +1036,66 @@ export async function processWorkflowRuns(
             const runDate = new Date(run.created_at);
             return runDate >= targetDate && runDate < nextDay;
         });
+    }
+
+    // Filter by branch based on workflow type
+    // - Repo workflows: match version branch (e.g., "2179.0" for GL 2179)
+    // - Other workflows: only "main" branch
+    // - Skip filtering if "search all branches" is enabled
+    const isRepoWorkflow =
+        workflow.id === WORKFLOW_IDS.REPO_BUILD ||
+        workflow.id === WORKFLOW_IDS.REPO_UPDATE;
+
+    if (!shouldSearchAllBranches() && targetRuns.length > 0) {
+        const beforeFilter = targetRuns.length;
+
+        const isRepoBuild = workflow.id === WORKFLOW_IDS.REPO_BUILD;
+        const isRepoUpdate = workflow.id === WORKFLOW_IDS.REPO_UPDATE;
+
+        if (isRepoBuild) {
+            // Repo Build workflow runs on version branches
+            // Version format v1 (GL < 2017): "1592.0"
+            // Version format v2 (GL >= 2017): "2179.0.0"
+            const expectedBranch = formatVersionBranch(glDays);
+            targetRuns = targetRuns.filter((run) => {
+                const isCorrectBranch = run.head_branch === expectedBranch;
+                if (!isCorrectBranch) {
+                    console.log(
+                        `🔍 [Branch Filter] GL${glDays} ${workflow.name}: Filtered out run #${run.run_number} from branch "${run.head_branch}" (expected "${expectedBranch}")`
+                    );
+                }
+                return isCorrectBranch;
+            });
+        } else if (isRepoUpdate) {
+            // Repo Update workflow always runs on main branch
+            targetRuns = targetRuns.filter((run) => {
+                const isMainBranch = run.head_branch === "main";
+                if (!isMainBranch) {
+                    console.log(
+                        `🔍 [Branch Filter] GL${glDays} ${workflow.name}: Filtered out run #${run.run_number} from branch "${run.head_branch}" (expected "main")`
+                    );
+                }
+                return isMainBranch;
+            });
+        } else {
+            // Non-repo workflows run on main branch
+            targetRuns = targetRuns.filter((run) => {
+                const isMainBranch = run.head_branch === "main";
+                if (!isMainBranch) {
+                    console.log(
+                        `🔍 [Branch Filter] GL${glDays} ${workflow.name}: Filtered out run #${run.run_number} from branch "${run.head_branch}" (expected "main")`
+                    );
+                }
+                return isMainBranch;
+            });
+        }
+
+        const afterFilter = targetRuns.length;
+        if (beforeFilter !== afterFilter) {
+            console.log(
+                `🔍 [Branch Filter] GL${glDays} ${workflow.name}: Filtered ${beforeFilter - afterFilter} runs from incorrect branches (${afterFilter} remaining)`
+            );
+        }
     }
 
     // Debug repo build workflow specifically (current AND historic)


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: Add client-side branch filtering to prevent wrong workflow runs from displaying from displaying
  
  The GitHub API's `branch` parameter doesn't reliably filter workflow runs, causing runs from incorrect branches to appear on the dashboard. This adds explicit client-side filtering after fetching runs.
  
  Changes:
  - Add formatVersionBranch() to handle version-aware branch naming (< GL 2017: "X.Y" format, >= GL 2017: "X.Y.Z" format)
  - Add branch filtering in processWorkflow() and processWorkflowRuns()
  - Repo Build: Filter by version branch (e.g., "2179.0.0")
  - Repo Update: Filter by "main" branch only
  - Other workflows (Nightly, Manual Release): Filter by "main" branch only
  - Respect "search all branches" setting to bypass filtering when enabled
  - Add detailed logging for filtered runs
  
  Fixes issue where Stage 3 workflows from non-main branches (e.g., "1877.14") were incorrectly displayed as "In Progress" on the current dashboard.
