### PR TITLE
feat: show global error banner on GitHub API rate limit / access denied

### DIFF
--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -18,7 +18,7 @@
  */
 
 import {
-    getAuthHeaders,
+    githubFetch,
     isHistoricView,
     getGlDays,
     formatGLDate,
@@ -246,11 +246,8 @@ async function processWorkflow(
     // Only filter by daily tag for the repo build workflow
     else if (workflow.id === WORKFLOW_IDS.REPO_BUILD) {
         try {
-            const tagResponse = await fetch(
-                `${API_CONFIG.GITHUB_API_BASE}/repos/${API_CONFIG.GARDENLINUX_ORG}/${workflow.repo}/git/ref/tags/${tagName}`,
-                {
-                    headers: getAuthHeaders(),
-                }
+            const tagResponse = await githubFetch(
+                `${API_CONFIG.GITHUB_API_BASE}/repos/${API_CONFIG.GARDENLINUX_ORG}/${workflow.repo}/git/ref/tags/${tagName}`
             );
             const tagData = await tagResponse.json();
             const commitSha = tagData.object.sha;
@@ -264,9 +261,7 @@ async function processWorkflow(
         apiUrl = `${API_CONFIG.GITHUB_API_BASE}/repos/${API_CONFIG.GARDENLINUX_ORG}/${workflow.repo}/actions/workflows/${workflowIdentifier}/runs?per_page=50${workflow.repo === "repo" ? getRepoBranchParameter() : getBranchParameter()}`;
     }
 
-    const response = await fetch(apiUrl, {
-        headers: getAuthHeaders(),
-    });
+    const response = await githubFetch(apiUrl);
 
     if (!response.ok) {
         console.error(
@@ -345,9 +340,7 @@ async function processWorkflow(
             for (let page = 1; page <= 5; page++) {
                 try {
                     const url = `${API_CONFIG.GITHUB_API_BASE}/repos/${API_CONFIG.GARDENLINUX_ORG}/${workflow.repo}/actions/workflows/${workflow.workflowFile || workflow.id}/runs?per_page=100&page=${page}${workflow.repo === "repo" ? getRepoBranchParameter() : getBranchParameter()}`;
-                    const resp = await fetch(url, {
-                        headers: getAuthHeaders(),
-                    });
+                    const resp = await githubFetch(url);
                     if (!resp.ok) break;
                     const data = await resp.json();
                     const pageRuns = data.workflow_runs || [];
@@ -1438,10 +1431,9 @@ async function getHistoricWorkflowStatuses(glDays) {
                     API_CONFIG.TIMEOUT
                 );
 
-                const response = await fetch(
+                const response = await githubFetch(
                     `${API_CONFIG.GITHUB_API_BASE}/repos/${API_CONFIG.GARDENLINUX_ORG}/${workflow.repo}/actions/workflows/${workflow.id}/runs?per_page=${API_CONFIG.HISTORIC_RUNS_PER_PAGE}${workflow.repo === "repo" ? getRepoBranchParameter() : getBranchParameter()}`,
                     {
-                        headers: getAuthHeaders(),
                         signal: controller.signal,
                     }
                 );

--- a/src/errorBanner.js
+++ b/src/errorBanner.js
@@ -1,0 +1,284 @@
+/**
+ * ========================================
+ * GARDEN LINUX DASHBOARD - GLOBAL ERROR BANNER
+ * ========================================
+ *
+ * Displays a single dismissible banner pinned to the very top of the page when
+ * a GitHub API request is denied. Handles two broad cases:
+ *   - Rate limiting (HTTP 403 with X-RateLimit-Remaining: 0, or 403/429 with
+ *     Retry-After) -> shows a live countdown until access is expected back.
+ *   - Access denied / authentication required (HTTP 401 or other 403) -> prompts
+ *     the user to check their token in Settings.
+ *
+ * The banner is created dynamically as the first child of <body> so it always
+ * renders above the header. It can be dismissed manually and auto-clears on the
+ * next successful GitHub API response.
+ */
+
+const BANNER_ID = "global-error-banner";
+
+// Grace period after an access-denied response during which a successful
+// response will NOT auto-clear the banner. The dashboard fires many GitHub
+// requests in parallel, so a sibling 200 can resolve microseconds after a
+// legitimate 403; without this window that success would wipe the banner
+// before the user ever sees it.
+const AUTO_CLEAR_GRACE_MS = 1500;
+
+// Tracks whether the user manually dismissed the current banner instance so we
+// don't immediately re-show an identical message on the next failing request.
+let dismissedSignature = null;
+let countdownIntervalId = null;
+// Timestamp of the most recent access-denied response, used to debounce
+// auto-clear against concurrent successful responses.
+let lastDenialAt = 0;
+
+/**
+ * Inspect a fetch Response and, if it indicates an access-denied condition,
+ * show the global banner. Any successful GitHub response clears an existing
+ * banner. Returns the same response for convenient pass-through.
+ *
+ * @param {Response} response
+ * @returns {Response}
+ */
+export function reportApiResponse(response) {
+    try {
+        if (!response) {
+            return response;
+        }
+
+        if (response.ok) {
+            // Don't let a success that resolves alongside a concurrent
+            // access-denied response immediately clear the banner.
+            if (Date.now() - lastDenialAt > AUTO_CLEAR_GRACE_MS) {
+                hideErrorBanner();
+            }
+            return response;
+        }
+
+        const status = response.status;
+        if (status !== 401 && status !== 403 && status !== 429) {
+            // Not an access-denied class of error; leave any existing banner as-is.
+            return response;
+        }
+
+        lastDenialAt = Date.now();
+        const classification = classifyResponse(response);
+        showErrorBanner(classification);
+    } catch (error) {
+        console.error("[ErrorBanner] Failed to report API response:", {
+            error: error && error.message,
+        });
+    }
+    return response;
+}
+
+/**
+ * Report a network-level failure (fetch threw before a response was produced).
+ * @param {Error} error
+ */
+export function reportNetworkError(error) {
+    // AbortError is an intentional timeout cancellation, not a connectivity issue.
+    if (error && error.name === "AbortError") {
+        return;
+    }
+    showErrorBanner({
+        type: "network",
+        message:
+            "Could not reach the GitHub API. Check your network connection and try again.",
+        resetAt: null,
+    });
+}
+
+/**
+ * Classify an access-denied response into a banner descriptor.
+ * @param {Response} response
+ * @returns {{type: string, message: string, resetAt: number|null}}
+ */
+function classifyResponse(response) {
+    const status = response.status;
+    const headers = response.headers;
+    const hasToken = Boolean(getStoredToken());
+
+    const rateRemaining = headers && headers.get("X-RateLimit-Remaining");
+    const retryAfter = headers && headers.get("Retry-After");
+    const rateReset = headers && headers.get("X-RateLimit-Reset");
+
+    const isPrimaryRateLimit =
+        status === 403 && rateRemaining !== null && Number(rateRemaining) === 0;
+    const isSecondaryRateLimit =
+        (status === 403 || status === 429) && retryAfter !== null;
+
+    if (isPrimaryRateLimit || isSecondaryRateLimit) {
+        const resetAt = computeResetAt(rateReset, retryAfter);
+        const base = "GitHub API rate limit exceeded.";
+        const advice = hasToken
+            ? ""
+            : " Add a Personal Access Token in Settings (\u2699\uFE0F) to raise the limit.";
+        return {
+            type: "rate-limit",
+            message: `${base}${advice}`,
+            resetAt,
+        };
+    }
+
+    // Remaining 401 / 403 cases: authentication or permission problem.
+    const message = hasToken
+        ? `GitHub access denied (${status}). Check that your token has the required permissions in Settings (\u2699\uFE0F).`
+        : `GitHub access denied (${status}). Add a Personal Access Token in Settings (\u2699\uFE0F) to access this data.`;
+    return {
+        type: "access-denied",
+        message,
+        resetAt: null,
+    };
+}
+
+/**
+ * Compute the epoch-milliseconds timestamp when access should return.
+ * @param {string|null} rateReset X-RateLimit-Reset (epoch seconds)
+ * @param {string|null} retryAfter Retry-After (seconds or HTTP date)
+ * @returns {number|null}
+ */
+function computeResetAt(rateReset, retryAfter) {
+    if (rateReset) {
+        const epochSeconds = Number(rateReset);
+        if (!Number.isNaN(epochSeconds) && epochSeconds > 0) {
+            return epochSeconds * 1000;
+        }
+    }
+    if (retryAfter) {
+        const seconds = Number(retryAfter);
+        if (!Number.isNaN(seconds) && seconds >= 0) {
+            return Date.now() + seconds * 1000;
+        }
+        const asDate = Date.parse(retryAfter);
+        if (!Number.isNaN(asDate)) {
+            return asDate;
+        }
+    }
+    return null;
+}
+
+/**
+ * Create or update the banner element.
+ * @param {{type: string, message: string, resetAt: number|null}} descriptor
+ */
+export function showErrorBanner(descriptor) {
+    if (typeof document === "undefined" || !document.body) {
+        return;
+    }
+
+    const signature = `${descriptor.type}|${descriptor.message}`;
+    if (signature === dismissedSignature) {
+        // User dismissed this exact message; respect that until it changes.
+        return;
+    }
+
+    let banner = document.getElementById(BANNER_ID);
+    if (banner && banner.dataset.signature === signature) {
+        // Same banner already shown; avoid rebuilding the subtree and resetting
+        // the countdown on every concurrent failing request.
+        return;
+    }
+    if (!banner) {
+        banner = document.createElement("div");
+        banner.id = BANNER_ID;
+        banner.className = "global-error-banner";
+        banner.setAttribute("role", "alert");
+        document.body.insertBefore(banner, document.body.firstChild);
+    }
+
+    banner.dataset.signature = signature;
+
+    const text = document.createElement("span");
+    text.className = "global-error-banner__text";
+    text.textContent = descriptor.message;
+
+    const countdown = document.createElement("span");
+    countdown.className = "global-error-banner__countdown";
+
+    const dismissBtn = document.createElement("button");
+    dismissBtn.type = "button";
+    dismissBtn.className = "global-error-banner__dismiss";
+    dismissBtn.setAttribute("aria-label", "Dismiss");
+    dismissBtn.textContent = "\u00D7";
+    dismissBtn.addEventListener("click", () => {
+        dismissedSignature = signature;
+        lastDenialAt = 0;
+        hideErrorBanner();
+    });
+
+    banner.replaceChildren(text, countdown, dismissBtn);
+
+    stopCountdown();
+    if (descriptor.resetAt) {
+        startCountdown(countdown, descriptor.resetAt);
+    }
+}
+
+/**
+ * Remove the banner and stop any running countdown.
+ */
+export function hideErrorBanner() {
+    stopCountdown();
+    if (typeof document === "undefined") {
+        return;
+    }
+    const banner = document.getElementById(BANNER_ID);
+    if (banner && banner.parentNode) {
+        banner.parentNode.removeChild(banner);
+    }
+}
+
+function startCountdown(element, resetAt) {
+    const render = () => {
+        const remainingMs = resetAt - Date.now();
+        if (remainingMs <= 0) {
+            element.textContent =
+                " Access should be available now \u2014 retrying shortly.";
+            stopCountdown();
+            return;
+        }
+        element.textContent = ` Resets in ${formatDuration(remainingMs)} (at ${formatClockTime(resetAt)}).`;
+    };
+    render();
+    countdownIntervalId = setInterval(render, 1000);
+}
+
+function stopCountdown() {
+    if (countdownIntervalId !== null) {
+        clearInterval(countdownIntervalId);
+        countdownIntervalId = null;
+    }
+}
+
+function formatDuration(ms) {
+    const totalSeconds = Math.ceil(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    if (minutes <= 0) {
+        return `${seconds}s`;
+    }
+    return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}
+
+function formatClockTime(epochMs) {
+    try {
+        return new Date(epochMs).toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+    } catch {
+        return new Date(epochMs).toISOString();
+    }
+}
+
+function getStoredToken() {
+    try {
+        if (typeof localStorage === "undefined") {
+            return null;
+        }
+        return localStorage.getItem("github_token");
+    } catch {
+        return null;
+    }
+}

--- a/src/parentWorkflow.js
+++ b/src/parentWorkflow.js
@@ -13,7 +13,7 @@
  */
 
 import { ALLOWED_ARTIFACT_NAMES, API_CONFIG } from "./constants.js";
-import { getAuthHeaders } from "./utils.js";
+import { githubFetch } from "./utils.js";
 import JSZip from "jszip";
 
 /**
@@ -32,11 +32,11 @@ export async function downloadAndExtractArtifact(owner, repo, artifact) {
                 message: `Artifact name '${artifact.name}' not in allowed list: ${ALLOWED_ARTIFACT_NAMES.join(", ")}`,
             };
         }
-        const downloadResponse = await fetch(
+        // A 401/403 here is an expected outcome for anonymous users and is
+        // handled locally below, so don't raise the global error banner.
+        const downloadResponse = await githubFetch(
             `${API_CONFIG.GITHUB_API_BASE}/repos/${owner}/${repo}/actions/artifacts/${artifact.id}/zip`,
-            {
-                headers: getAuthHeaders(),
-            }
+            { reportErrors: false }
         );
         if (!downloadResponse.ok) {
             const status = downloadResponse.status;
@@ -131,11 +131,8 @@ export async function getParentWorkflowInfo(owner, repo, runId) {
     try {
         // First, try to get parent workflow info from the workflow_run event
         // This is more reliable and doesn't require downloading artifacts
-        const runResponse = await fetch(
-            `${API_CONFIG.GITHUB_API_BASE}/repos/${owner}/${repo}/actions/runs/${runId}`,
-            {
-                headers: getAuthHeaders(),
-            }
+        const runResponse = await githubFetch(
+            `${API_CONFIG.GITHUB_API_BASE}/repos/${owner}/${repo}/actions/runs/${runId}`
         );
 
         if (runResponse.ok) {
@@ -153,11 +150,8 @@ export async function getParentWorkflowInfo(owner, repo, runId) {
         }
 
         // Fall back to artifact-based detection if workflow_run event doesn't provide parent info
-        const artifactsResponse = await fetch(
-            `${API_CONFIG.GITHUB_API_BASE}/repos/${owner}/${repo}/actions/runs/${runId}/artifacts`,
-            {
-                headers: getAuthHeaders(),
-            }
+        const artifactsResponse = await githubFetch(
+            `${API_CONFIG.GITHUB_API_BASE}/repos/${owner}/${repo}/actions/runs/${runId}/artifacts`
         );
         if (!artifactsResponse.ok) {
             console.error(

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,6 +26,8 @@ import {
     formatVersionBranch,
 } from "./constants.js";
 
+import { reportApiResponse, reportNetworkError } from "./errorBanner.js";
+
 // ========================================
 // DATE AND GL VERSION CALCULATIONS
 // ========================================
@@ -242,6 +244,40 @@ export function getAuthHeaders() {
             Accept: "application/vnd.github.v3+json",
             "X-GitHub-Api-Version": "2022-11-28",
         };
+    }
+}
+
+/**
+ * Wrapper around fetch() for GitHub API requests.
+ *
+ * Injects the standard auth headers (unless the caller already supplied
+ * headers), routes the response through the global error banner so that
+ * access-denied / rate-limit responses are surfaced at the top of the page,
+ * and clears the banner on success. Returns the same Response the caller
+ * would get from fetch(), so existing per-workflow handling is unaffected.
+ *
+ * Pass `reportErrors: false` for endpoints where an access-denied response is
+ * an expected, locally-handled outcome (e.g. anonymous artifact downloads) so
+ * it does not raise a page-level banner.
+ *
+ * @param {string} url
+ * @param {RequestInit & { reportErrors?: boolean }} [options]
+ * @returns {Promise<Response>}
+ */
+export async function githubFetch(url, options = {}) {
+    const { reportErrors = true, ...fetchOptions } = options;
+    const headers = fetchOptions.headers || getAuthHeaders();
+    try {
+        const response = await fetch(url, { ...fetchOptions, headers });
+        if (reportErrors) {
+            reportApiResponse(response);
+        }
+        return response;
+    } catch (error) {
+        if (reportErrors) {
+            reportNetworkError(error);
+        }
+        throw error;
     }
 }
 
@@ -763,7 +799,7 @@ export async function collectStage3RunIds(
     glDays
 ) {
     try {
-        const { getAuthHeaders, getBranchParameter, getRepoBranchParameter } =
+        const { getBranchParameter, getRepoBranchParameter } =
             await import("./utils.js");
         const { API_CONFIG } = await import("./constants.js");
 
@@ -771,9 +807,8 @@ export async function collectStage3RunIds(
 
         for (const workflow of stage3Workflows) {
             try {
-                const response = await fetch(
-                    `${API_CONFIG.GITHUB_API_BASE}/repos/${API_CONFIG.GARDENLINUX_ORG}/${workflow.repo}/actions/workflows/${workflow.id}/runs?per_page=${API_CONFIG.HISTORIC_RUNS_PER_PAGE}${workflow.repo === "repo" ? getRepoBranchParameter() : getBranchParameter()}`,
-                    { headers: getAuthHeaders() }
+                const response = await githubFetch(
+                    `${API_CONFIG.GITHUB_API_BASE}/repos/${API_CONFIG.GARDENLINUX_ORG}/${workflow.repo}/actions/workflows/${workflow.id}/runs?per_page=${API_CONFIG.HISTORIC_RUNS_PER_PAGE}${workflow.repo === "repo" ? getRepoBranchParameter() : getBranchParameter()}`
                 );
 
                 if (!response.ok) {

--- a/style.css
+++ b/style.css
@@ -1588,6 +1588,69 @@ table {
     border-color: var(--color-failure);
 }
 
+/* GLOBAL ERROR BANNER */
+.global-error-banner {
+    position: sticky;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 2000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 12px 48px 12px 20px;
+    background: var(--color-failure);
+    color: var(--text-white);
+    font-size: 0.95em;
+    line-height: 1.4;
+    text-align: center;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+    animation: global-error-banner-slide-in 0.2s ease-out;
+}
+
+.global-error-banner__text {
+    font-weight: 600;
+}
+
+.global-error-banner__countdown {
+    opacity: 0.9;
+    font-variant-numeric: tabular-nums;
+}
+
+.global-error-banner__dismiss {
+    position: absolute;
+    top: 50%;
+    right: 14px;
+    transform: translateY(-50%);
+    background: transparent;
+    border: none;
+    color: var(--text-white);
+    font-size: 1.4em;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 6px;
+    opacity: 0.85;
+}
+
+.global-error-banner__dismiss:hover {
+    opacity: 1;
+}
+
+@keyframes global-error-banner-slide-in {
+    from {
+        transform: translateY(-100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
 /* SETTINGS PANEL */
 #settings-container {
     position: fixed;
@@ -2086,6 +2149,11 @@ table {
 
 /* RESPONSIVE DESIGN */
 @media (max-width: 768px) {
+    .global-error-banner {
+        font-size: 0.85em;
+        padding: 10px 40px 10px 14px;
+    }
+
     .header-title {
         gap: 15px;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a sticky top-of-page banner that surfaces when any GitHub API call returns 401, 403 (rate limit or auth), or 429. The banner shows a live countdown to the rate-limit reset and prompts unauthenticated users to add a PAT. It auto-clears on the next successful request (with a 1.5 s grace window to avoid parallel-request races) and can be dismissed manually.

Route all GitHub fetches through a new githubFetch() wrapper in utils.js (replacing 8 raw fetch call sites) that injects auth headers and drives the banner. Artifact downloads that expect a 403 for anonymous users opt out via { reportErrors: false } to avoid false-positive banners.